### PR TITLE
added tests for o,x,X specificators, fixed clang-format

### DIFF
--- a/src/String/includes/s21_sprintf.h
+++ b/src/String/includes/s21_sprintf.h
@@ -1,7 +1,7 @@
 #ifndef SRC_S21_SPRINTF_H_
 #define SRC_S21_SPRINTF_H_
-#include <stdarg.h>
 #include <limits.h>
+#include <stdarg.h>
 
 #include "s21_string.h"
 

--- a/src/String/includes/s21_string.h
+++ b/src/String/includes/s21_string.h
@@ -5,8 +5,8 @@
 
 #define S21_TEXTMAX 2048
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 typedef long unsigned s21_size_t;
 
@@ -28,6 +28,6 @@ void *s21_to_upper(const char *str);
 void *s21_to_lower(const char *str);
 void *s21_insert(const char *src, const char *str, s21_size_t start_index);
 void *s21_trim(const char *src, const char *trim_chars);
-int s21_sprintf(char* str, const char* format, ...);
+int s21_sprintf(char *str, const char *format, ...);
 
 #endif

--- a/src/String/s21_sprintf.c
+++ b/src/String/s21_sprintf.c
@@ -32,7 +32,7 @@ int s21_sprintf(char* str, const char* format, ...) {
           d_specific(temp, list, p, len, &i, str, num, &size);
           break;
         case 'f':
-          str = (char*) f_specific(list, p, temp, len, &i, str, pers_num, &size);
+          str = (char*)f_specific(list, p, temp, len, &i, str, pers_num, &size);
           break;
         case 's':
           s_specific(list, p, len, &i, str);
@@ -61,6 +61,22 @@ int s21_sprintf(char* str, const char* format, ...) {
   return res;
 }
 
+void flag_plus(va_list list, char* str, int* i, int* num) {
+  *num = va_arg(list, unsigned int);
+  if (*num >= 0) {
+    s21_memset(&str[*i], '+', 1);
+    *i += 1;
+  }
+}
+
+void flag_space(va_list list, char* str, int* i, int* num) {
+  *num = va_arg(list, unsigned int);
+  if (*num >= 0) {
+    s21_memset(&str[*i], ' ', 1);
+    *i += 1;
+  }
+}
+
 int get_num(char** str) {
   char ch;
   char temp[10];
@@ -75,32 +91,10 @@ int get_num(char** str) {
   return atoi(temp);
 }
 
-char* s21_itoa(int input, char* buff, int num) {
-  int base = 10;
-  char* p;
-  if (num < 0) {
-    num = -num;
-    p = s21_convert(buff, input, num, base);
-    *--p = '-';
-  } else {
-    p = s21_convert(buff, input, num, base);
-  }
-  return p;
-}
-
-char* s21_convert(char* buff, int size, unsigned int num, int base) {
-  char* p;
-  p = &buff[size - 1];
-  *p = '\0';
-  if (num != 0) {
-    while (num != 0) {
-      *--p = "0123456789ABCDEF"[num % base];
-      num /= base;
-    }
-  } else {
-    *--p = '0';
-  }
-  return p;
+void c_specific(va_list list, char* str, int* i) {
+  char c = va_arg(list, int);
+  s21_memset(&str[*i], c, 1);
+  *i += 1;
 }
 
 void d_specific(char* temp, va_list list, char* p, s21_size_t len, int* i,
@@ -116,34 +110,23 @@ void d_specific(char* temp, va_list list, char* p, s21_size_t len, int* i,
   *size += len;
 }
 
+char* f_specific(va_list list, char* p, char* temp, s21_size_t len, int* i,
+                 char* str, int pers_num, int* size) {
+  float value = (float)va_arg(list, double);
+  p = s21_ftoa(temp, sizeof(temp), value, pers_num);
+  len = s21_strlen(p);
+  s21_strncat(&str[*i], p, s21_strlen(p));
+  *i += len;
+  *size += len;
+  return str;
+}
+
 void s_specific(va_list list, char* p, unsigned char len, int* i, char* str) {
   p = va_arg(list, char*);
   len = (unsigned char)s21_strlen(p);
   s21_memset(&str[*i], ' ', 0);
   s21_strncat(&str[*i], p, len);
   *i += (len);
-}
-
-void c_specific(va_list list, char* str, int* i) {
-  char c = va_arg(list, int);
-  s21_memset(&str[*i], c, 1);
-  *i += 1;
-}
-
-void flag_plus(va_list list, char* str, int* i, int* num) {
-  *num = va_arg(list, unsigned int);
-    if (*num >= 0) {
-    s21_memset(&str[*i], '+', 1);
-    *i += 1;
-  }
-}
-
-void flag_space(va_list list, char* str, int* i, int* num) {
-  *num = va_arg(list, unsigned int);
-  if (*num >= 0) {
-    s21_memset(&str[*i], ' ', 1);
-    *i += 1;
-  }
 }
 
 void o_specific(va_list list, char* str, int* i) {
@@ -191,6 +174,34 @@ void x_specific(va_list list, char* str, int* i, int spec_x) {
   }
 }
 
+char* s21_itoa(int input, char* buff, int num) {
+  int base = 10;
+  char* p;
+  if (num < 0) {
+    num = -num;
+    p = s21_convert(buff, input, num, base);
+    *--p = '-';
+  } else {
+    p = s21_convert(buff, input, num, base);
+  }
+  return p;
+}
+
+char* s21_convert(char* buff, int size, unsigned int num, int base) {
+  char* p;
+  p = &buff[size - 1];
+  *p = '\0';
+  if (num != 0) {
+    while (num != 0) {
+      *--p = "0123456789ABCDEF"[num % base];
+      num /= base;
+    }
+  } else {
+    *--p = '0';
+  }
+  return p;
+}
+
 char* s21_reverse(char* str) {
   char tmp;
   s21_size_t i, j;
@@ -201,17 +212,6 @@ char* s21_reverse(char* str) {
     str[j] = tmp;
   }
   return str;
-}
-
-char* f_specific(va_list list, char* p, char* temp, s21_size_t len, int* i,
-                char* str, int pers_num, int* size) {
-  float value = (float)va_arg(list, double);
-  p = s21_ftoa(temp, sizeof(temp), value, pers_num);
-  len = s21_strlen(p);
-  s21_strncat(&str[*i], p, s21_strlen(p));
-  *i += len;
-    *size += len;
-    return str;
 }
 
 char* f_to_str(char* buff, int size, float value, int digits, int* flag) {
@@ -270,19 +270,26 @@ char* s21_ftoa(char* buff, int size, float value, int digits) {
   s21_strncat(q, p, p_count);
   return q;
 }
+
 void u_specific(void) {}
 
 void percent_specific(void) {}
 
-    //  int main () {
-    //    char buffer1[100];
-    //    char buffer2[100];
-    //    //int str3 = 4.3;
-    //  //    size_t n = strlen(str3);
-    //  //    size_t m = s21_strlen(str3);
-    //  //    printf("%lu %lu \n", n, m);
-
-    //    s21_sprintf(buffer1, "s21   :% d", 0);
-    //    sprintf(buffer2, "origin: % d", 0);
-    //    printf("%s \n%s\n", buffer1, buffer2);
-    //  }
+//   int main () {
+//     char buffer1[100];
+//     char buffer2[100];
+//     //int str3 = 4.3;
+//   //    size_t n = strlen(str3);
+//   //    size_t m = s21_strlen(str3);
+//   //    printf("%lu %lu \n", n, m);
+//
+////       char s21_buff[100] = "";
+////       char buff[100] = "";
+////       s21_sprintf(s21_buff, "% d", 0);
+////       sprintf(buff, "% d", 0);
+////       printf("%s \n%s\n", s21_buff, buff);
+//
+//     s21_sprintf(buffer1, "s21   : % d", 0);
+//     sprintf(buffer2, "origin: % d", 0);
+//     printf("%s \n%s\n", buffer1, buffer2);
+//   }

--- a/src/String/s21_to_lower.c
+++ b/src/String/s21_to_lower.c
@@ -6,7 +6,7 @@ void *s21_to_lower(const char *str) {
   }
   int len = s21_strlen(str);
   char *copy_str = (char *)malloc((len + 1) * sizeof(char));
-  for (int i = 0; str[i] != '\0'; i++) { 
+  for (int i = 0; str[i] != '\0'; i++) {
     if (str[i] >= 'A' && str[i] <= 'Z') {
       copy_str[i] = str[i] + 32;
     } else {

--- a/src/StringUnittest/s21_sprintf_test.c
+++ b/src/StringUnittest/s21_sprintf_test.c
@@ -84,16 +84,6 @@ START_TEST(s_str_in_middle_of_str) {
 }
 END_TEST
 
-START_TEST(c_simple_char) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%c", 'c');
-  sprintf(buff, "%c", 'c');
-  
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
 START_TEST(f_simple) {
   char s21_buff[100] = "";
   char buff[100] = "";
@@ -102,16 +92,6 @@ START_TEST(f_simple) {
   s21_sprintf(s21_buff, "This is %f number", s21);
   sprintf(buff, "This is %f number", system);
 
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
-START_TEST(c_number_ASCII) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%c", 67);
-  sprintf(buff, "%c", 67);
-  
   ck_assert_pstr_eq(s21_buff, buff);
 }
 END_TEST
@@ -128,15 +108,6 @@ START_TEST(f_simple_zero) {
 }
 END_TEST
 
-START_TEST(c_number_char) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%c", '8');
-  sprintf(buff, "%c", '8');
- ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
 START_TEST(f_big_number) {
   char s21_buff[100] = "";
   char buff[100] = "";
@@ -145,15 +116,6 @@ START_TEST(f_big_number) {
   s21_sprintf(s21_buff, "This is %f number", s21);
   sprintf(buff, "This is %f number", system);
 
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
-START_TEST(c_space_char) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%c", ' ');
-  sprintf(buff, "%c", ' ');
   ck_assert_pstr_eq(s21_buff, buff);
 }
 END_TEST
@@ -170,15 +132,6 @@ START_TEST(f_big_int_part) {
 }
 END_TEST
 
-START_TEST(flag_plus_simple_test) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%+d", 21);
-  sprintf(buff, "%+d", 21);
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
 START_TEST(f_zero) {
   char s21_buff[100] = "";
   char buff[100] = "";
@@ -187,15 +140,6 @@ START_TEST(f_zero) {
   s21_sprintf(s21_buff, "This is %f number", s21);
   sprintf(buff, "This is %f number", system);
 
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
-START_TEST(flag_plus_negative_number) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%+d", -250);
-  sprintf(buff, "%+d", -250);
   ck_assert_pstr_eq(s21_buff, buff);
 }
 END_TEST
@@ -212,15 +156,6 @@ START_TEST(exactness_simple) {
 }
 END_TEST
 
-START_TEST(flag_plus_zero) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "%+d", 0);
-  sprintf(buff, "%+d", 0);
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
 START_TEST(exactness_with_simple_rounding) {
   char s21_buff[100] = "";
   char buff[100] = "";
@@ -233,15 +168,6 @@ START_TEST(exactness_with_simple_rounding) {
 }
 END_TEST
 
-START_TEST(flag_space_simple_test) {
-  char s21_buff[100] = "";
-  char buff[100] = "";
-  s21_sprintf(s21_buff, "% d", 25);
-  sprintf(buff, "% d", 25);
-  ck_assert_pstr_eq(s21_buff, buff);
-}
-END_TEST
-
 START_TEST(exactness_with_hard_rounding) {
   char s21_buff[100] = "";
   char buff[100] = "";
@@ -250,6 +176,92 @@ START_TEST(exactness_with_hard_rounding) {
   s21_sprintf(s21_buff, "This is %.3f number", s21);
   sprintf(buff, "This is %.3f number", system);
 
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(exactness_with_hard_rounding_minus) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  float s21 = -2.3228;
+  float system = -2.3228;
+  s21_sprintf(s21_buff, "This is %.3f number", s21);
+  sprintf(buff, "This is %.3f number", system);
+
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(c_simple_char) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%c", 'c');
+  sprintf(buff, "%c", 'c');
+
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(c_number_ASCII) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%c", 67);
+  sprintf(buff, "%c", 67);
+
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(c_number_char) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%c", '8');
+  sprintf(buff, "%c", '8');
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(c_space_char) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%c", ' ');
+  sprintf(buff, "%c", ' ');
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(flag_plus_simple_test) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%+d", 21);
+  sprintf(buff, "%+d", 21);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(flag_plus_negative_number) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%+d", -250);
+  sprintf(buff, "%+d", -250);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(flag_plus_zero) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "result: %+d", 0);
+  sprintf(buff, "result: %+d", 0);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(flag_space_simple_test) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "result: % d", 25);
+  sprintf(buff, "result: % d", 25);
   ck_assert_pstr_eq(s21_buff, buff);
 }
 END_TEST
@@ -273,14 +285,92 @@ START_TEST(flag_space_zero) {
 }
 END_TEST
 
-START_TEST(exactness_with_hard_rounding_minus) {
+START_TEST(x_simple_test) {
   char s21_buff[100] = "";
   char buff[100] = "";
-  float s21 = -2.3228;
-  float system = -2.3228;
-  s21_sprintf(s21_buff, "This is %.3f number", s21);
-  sprintf(buff, "This is %.3f number", system);
+  s21_sprintf(s21_buff, "%x", 15);
+  sprintf(buff, "%x", 15);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
 
+START_TEST(X_simple_test) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%X", 11);
+  sprintf(buff, "%X", 11);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(x_big_number) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%x", 1505);
+  sprintf(buff, "%x", 1505);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(X_big_number) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%X", 12345678);
+  sprintf(buff, "%X", 12345678);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(x_zero) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%x", 0);
+  sprintf(buff, "%x", 0);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(X_zero) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%X", 0);
+  sprintf(buff, "%X", 0);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(o_simple_test) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%o", 10);
+  sprintf(buff, "%o", 10);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(o_before_eight) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%o", 7);
+  sprintf(buff, "%o", 7);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(o_zero) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%o", 0);
+  sprintf(buff, "%o", 0);
+  ck_assert_pstr_eq(s21_buff, buff);
+}
+END_TEST
+
+START_TEST(o_big_number) {
+  char s21_buff[100] = "";
+  char buff[100] = "";
+  s21_sprintf(s21_buff, "%o", 12345678);
+  sprintf(buff, "%o", 12345678);
   ck_assert_pstr_eq(s21_buff, buff);
 }
 END_TEST
@@ -296,6 +386,15 @@ Suite* suite_sprintf() {
   tcase_add_test(tcase_core, s_empty_test);
   tcase_add_test(tcase_core, s_int_str_test);
   tcase_add_test(tcase_core, s_str_in_middle_of_str);
+  tcase_add_test(tcase_core, f_simple);
+  tcase_add_test(tcase_core, f_simple_zero);
+  tcase_add_test(tcase_core, f_big_number);
+  tcase_add_test(tcase_core, f_big_int_part);
+  tcase_add_test(tcase_core, f_zero);
+  tcase_add_test(tcase_core, exactness_simple);
+  tcase_add_test(tcase_core, exactness_with_simple_rounding);
+  tcase_add_test(tcase_core, exactness_with_hard_rounding);
+  tcase_add_test(tcase_core, exactness_with_hard_rounding_minus);
   tcase_add_test(tcase_core, c_simple_char);
   tcase_add_test(tcase_core, c_number_ASCII);
   tcase_add_test(tcase_core, c_number_char);
@@ -306,16 +405,17 @@ Suite* suite_sprintf() {
   tcase_add_test(tcase_core, flag_space_simple_test);
   tcase_add_test(tcase_core, flag_space_negative_number);
   tcase_add_test(tcase_core, flag_space_zero);
-  tcase_add_test(tcase_core, f_simple);
-  tcase_add_test(tcase_core, f_simple_zero);
-  tcase_add_test(tcase_core, f_big_number);
-  tcase_add_test(tcase_core, f_big_int_part);
-  tcase_add_test(tcase_core, f_zero);
-  tcase_add_test(tcase_core, exactness_simple);
-  tcase_add_test(tcase_core, exactness_with_simple_rounding);
-  tcase_add_test(tcase_core, exactness_with_hard_rounding);
-  tcase_add_test(tcase_core, exactness_with_hard_rounding_minus);
-   
+  tcase_add_test(tcase_core, x_simple_test);
+  tcase_add_test(tcase_core, X_simple_test);
+  tcase_add_test(tcase_core, x_big_number);
+  tcase_add_test(tcase_core, X_big_number);
+  tcase_add_test(tcase_core, x_zero);
+  tcase_add_test(tcase_core, X_zero);
+  tcase_add_test(tcase_core, o_simple_test);
+  tcase_add_test(tcase_core, o_before_eight);
+  tcase_add_test(tcase_core, o_zero);
+  tcase_add_test(tcase_core, o_big_number);
+
   suite_add_tcase(suite, tcase_core);
   return suite;
 }

--- a/src/StringUnittest/s21_tests.c
+++ b/src/StringUnittest/s21_tests.c
@@ -24,26 +24,12 @@ void run_testcase(Suite *testcase) {
 }
 
 void run_tests(void) {
-  Suite *list_cases[] = {suite_memchr(),
-                         suite_memset(),
-                         suite_strchr(),
-                         suite_strerror(),
-                         suite_strlen(),
-                         suite_strncat(),
-                         suite_strncmp(),
-                         suite_memcmp(),
-                         suite_memcpy(),
-                         suite_strncpy(),
-                         suite_strpbrk(),
-                         suite_strrchr(),
-                         suite_strstr(),
-                         suite_strtok(),
-                         suite_insert(),
-                         suite_trim(),
-                         suite_to_upper(),
-                         suite_to_lower(),
-                         suite_sprintf(),
-                         NULL};
+  Suite *list_cases[] = {
+      suite_memchr(),   suite_memset(),   suite_strchr(),  suite_strerror(),
+      suite_strlen(),   suite_strncat(),  suite_strncmp(), suite_memcmp(),
+      suite_memcpy(),   suite_strncpy(),  suite_strpbrk(), suite_strrchr(),
+      suite_strstr(),   suite_strtok(),   suite_insert(),  suite_trim(),
+      suite_to_upper(), suite_to_lower(), suite_sprintf(), NULL};
 
   for (Suite **current_testcase = list_cases; *current_testcase != NULL;
        current_testcase++) {


### PR DESCRIPTION
Добавлены тесты для спецификаторов o,x,X. Исправлен стиль во всех файлах, где это требовалось(clang-format). Я все. :)